### PR TITLE
Implement database abstraction layer

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,10 +4,10 @@ import { AppService } from './app.service';
 import { ScheduleModule } from './schedules/schedule.module';
 import { CalendarModule } from './calendars/calendar.module';
 import { UserModule } from './users/user.module';
-import { SQLiteModule } from './db/sqlite.module';
+import { DatabaseModule } from './db/database.module';
 
 @Module({
-  imports: [SQLiteModule, ScheduleModule, CalendarModule, UserModule],
+  imports: [DatabaseModule, ScheduleModule, CalendarModule, UserModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/server/src/calendars/calendar.module.ts
+++ b/server/src/calendars/calendar.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CalendarController } from './calendar.controller';
 import { CalendarService } from './calendar.service';
-import { SQLiteModule } from '../db/sqlite.module';
+import { DatabaseModule } from '../db/database.module';
 
 @Module({
-  imports: [SQLiteModule],
+  imports: [DatabaseModule],
   controllers: [CalendarController],
   providers: [CalendarService],
   exports: [CalendarService],

--- a/server/src/calendars/calendar.service.ts
+++ b/server/src/calendars/calendar.service.ts
@@ -1,24 +1,32 @@
 import { Injectable } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import { SQLiteService } from '../db/sqlite.service';
+import { DatabaseService } from '../db/database.service';
 import { Calendar } from './calendar.interface';
 
 @Injectable()
 export class CalendarService {
-  constructor(private readonly db: SQLiteService) {}
+  constructor(private readonly db: DatabaseService) {}
 
   async create(calendar: Omit<Calendar, 'id'>): Promise<Calendar> {
     const id = randomUUID();
     await this.db.run(
       `INSERT INTO calendars (id, userId, name, color, description) VALUES (?, ?, ?, ?, ?)`,
-      [id, calendar.userId, calendar.name, calendar.color ?? null, calendar.description ?? null],
+      [
+        id,
+        calendar.userId,
+        calendar.name,
+        calendar.color ?? null,
+        calendar.description ?? null,
+      ],
     );
     return { id, ...calendar };
   }
 
   async findAll(userId?: string): Promise<Calendar[]> {
     if (userId) {
-      return this.db.all<Calendar>(`SELECT * FROM calendars WHERE userId = ?`, [userId]);
+      return this.db.all<Calendar>(`SELECT * FROM calendars WHERE userId = ?`, [
+        userId,
+      ]);
     }
     return this.db.all<Calendar>(`SELECT * FROM calendars`);
   }
@@ -27,13 +35,22 @@ export class CalendarService {
     return this.db.get<Calendar>(`SELECT * FROM calendars WHERE id = ?`, [id]);
   }
 
-  async update(id: string, update: Partial<Calendar>): Promise<Calendar | undefined> {
+  async update(
+    id: string,
+    update: Partial<Calendar>,
+  ): Promise<Calendar | undefined> {
     const existing = await this.findOne(id);
     if (!existing) return undefined;
     const merged = { ...existing, ...update };
     await this.db.run(
       `UPDATE calendars SET userId = ?, name = ?, color = ?, description = ? WHERE id = ?`,
-      [merged.userId, merged.name, merged.color ?? null, merged.description ?? null, id],
+      [
+        merged.userId,
+        merged.name,
+        merged.color ?? null,
+        merged.description ?? null,
+        id,
+      ],
     );
     return merged;
   }

--- a/server/src/db/database.module.ts
+++ b/server/src/db/database.module.ts
@@ -1,0 +1,16 @@
+import { Module, Provider } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+import { SQLiteService } from './sqlite.service';
+import { PostgresService } from './postgres.service';
+
+const databaseProvider: Provider = {
+  provide: DatabaseService,
+  useClass:
+    process.env.DB_TYPE === 'postgres' ? PostgresService : SQLiteService,
+};
+
+@Module({
+  providers: [SQLiteService, PostgresService, databaseProvider],
+  exports: [DatabaseService],
+})
+export class DatabaseModule {}

--- a/server/src/db/database.service.ts
+++ b/server/src/db/database.service.ts
@@ -1,0 +1,7 @@
+export abstract class DatabaseService {
+  abstract onModuleInit(): void | Promise<void>;
+  abstract onModuleDestroy(): void | Promise<void>;
+  abstract run(sql: string, params?: any[]): Promise<void>;
+  abstract get<T>(sql: string, params?: any[]): Promise<T | undefined>;
+  abstract all<T>(sql: string, params?: any[]): Promise<T[]>;
+}

--- a/server/src/db/postgres.service.ts
+++ b/server/src/db/postgres.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+
+@Injectable()
+export class PostgresService
+  extends DatabaseService
+  implements OnModuleInit, OnModuleDestroy
+{
+  onModuleInit() {
+    // TODO: PostgreSQL 초기화 로직 작성
+  }
+
+  onModuleDestroy() {
+    // TODO: PostgreSQL 종료 로직 작성
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  run(sql: string, _params: any[] = []): Promise<void> {
+    // TODO: PostgreSQL 명령 실행 로직 작성
+    return Promise.reject(new Error('Not implemented'));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  get<T>(sql: string, _params: any[] = []): Promise<T | undefined> {
+    // TODO: PostgreSQL 조회 로직 작성
+    return Promise.reject(new Error('Not implemented'));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  all<T>(sql: string, _params: any[] = []): Promise<T[]> {
+    // TODO: PostgreSQL 여러 행 조회 로직 작성
+    return Promise.reject(new Error('Not implemented'));
+  }
+}

--- a/server/src/db/sqlite.module.ts
+++ b/server/src/db/sqlite.module.ts
@@ -1,8 +1,0 @@
-import { Module } from '@nestjs/common';
-import { SQLiteService } from './sqlite.service';
-
-@Module({
-  providers: [SQLiteService],
-  exports: [SQLiteService],
-})
-export class SQLiteModule {}

--- a/server/src/db/sqlite.service.ts
+++ b/server/src/db/sqlite.service.ts
@@ -1,9 +1,13 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { Database } from 'sqlite3';
 import { join } from 'path';
+import { DatabaseService } from './database.service';
 
 @Injectable()
-export class SQLiteService implements OnModuleInit, OnModuleDestroy {
+export class SQLiteService
+  extends DatabaseService
+  implements OnModuleInit, OnModuleDestroy
+{
   private db!: Database;
 
   onModuleInit() {

--- a/server/src/schedules/schedule.module.ts
+++ b/server/src/schedules/schedule.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ScheduleController } from './schedule.controller';
 import { ScheduleService } from './schedule.service';
-import { SQLiteModule } from '../db/sqlite.module';
+import { DatabaseModule } from '../db/database.module';
 
 @Module({
-  imports: [SQLiteModule],
+  imports: [DatabaseModule],
   controllers: [ScheduleController],
   providers: [ScheduleService],
   exports: [ScheduleService],

--- a/server/src/schedules/schedule.service.ts
+++ b/server/src/schedules/schedule.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { randomUUID } from 'crypto';
-import { SQLiteService } from '../db/sqlite.service';
+import { DatabaseService } from '../db/database.service';
 import { Schedule } from './schedule.interface';
 
 @Injectable()
 export class ScheduleService {
-  constructor(private readonly db: SQLiteService) {}
+  constructor(private readonly db: DatabaseService) {}
 
   async create(schedule: Omit<Schedule, 'id'>): Promise<Schedule> {
     const id = randomUUID();
@@ -45,7 +45,10 @@ export class ScheduleService {
       params.push(calendarId);
     }
     const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
-    const rows = await this.db.all<Schedule>(`SELECT * FROM schedules ${where}`, params);
+    const rows = await this.db.all<Schedule>(
+      `SELECT * FROM schedules ${where}`,
+      params,
+    );
     return rows;
   }
 

--- a/server/src/users/user.module.ts
+++ b/server/src/users/user.module.ts
@@ -2,10 +2,10 @@ import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { CalendarModule } from '../calendars/calendar.module';
-import { SQLiteModule } from '../db/sqlite.module';
+import { DatabaseModule } from '../db/database.module';
 
 @Module({
-  imports: [CalendarModule, SQLiteModule],
+  imports: [CalendarModule, DatabaseModule],
   controllers: [UserController],
   providers: [UserService],
 })

--- a/server/src/users/user.service.ts
+++ b/server/src/users/user.service.ts
@@ -2,18 +2,22 @@ import { Injectable } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { User } from './user.interface';
 import { CalendarService } from '../calendars/calendar.service';
-import { SQLiteService } from '../db/sqlite.service';
+import { DatabaseService } from '../db/database.service';
 
 @Injectable()
 export class UserService {
   constructor(
     private readonly calendarService: CalendarService,
-    private readonly db: SQLiteService,
+    private readonly db: DatabaseService,
   ) {}
 
   async create(user: Omit<User, 'id'>): Promise<User> {
     const id = randomUUID();
-    await this.db.run(`INSERT INTO users (id, name, email) VALUES (?, ?, ?)`, [id, user.name, user.email]);
+    await this.db.run(`INSERT INTO users (id, name, email) VALUES (?, ?, ?)`, [
+      id,
+      user.name,
+      user.email,
+    ]);
     const newUser: User = { id, ...user };
     await this.calendarService.create({ userId: newUser.id, name: 'default' });
     return newUser;
@@ -31,7 +35,11 @@ export class UserService {
     const existing = await this.findOne(id);
     if (!existing) return undefined;
     const merged = { ...existing, ...update };
-    await this.db.run(`UPDATE users SET name = ?, email = ? WHERE id = ?`, [merged.name, merged.email, id]);
+    await this.db.run(`UPDATE users SET name = ?, email = ? WHERE id = ?`, [
+      merged.name,
+      merged.email,
+      id,
+    ]);
     return merged;
   }
 


### PR DESCRIPTION
## Summary
- add `DatabaseService` abstract class and dynamic `DatabaseModule`
- implement placeholder `PostgresService`
- refactor `SQLiteService` to extend `DatabaseService`
- swap modules and services to depend on `DatabaseModule`
- remove old `SQLiteModule`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ba26e6e00832aaa0b08d65e98c64c