### PR TITLE
Add Swagger schema DTOs

### DIFF
--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -5,7 +5,10 @@ import { Body, Controller, Post, Req, Res } from '@nestjs/common';
 import { Response, Request } from 'express';
 import { AuthService } from './auth.service';
 import { UserService } from '../users/user.service';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { LoginDto } from './dto/login.dto';
 
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(
@@ -14,10 +17,9 @@ export class AuthController {
   ) {}
 
   @Post('login')
-  async login(
-    @Body() body: { email: string; password: string },
-    @Res() res: Response,
-  ) {
+  @ApiOperation({ summary: 'User login' })
+  @ApiBody({ type: LoginDto })
+  async login(@Body() body: LoginDto, @Res() res: Response) {
     const user = await this.auth.validateUser(body.email, body.password);
     if (!user) {
       return res.status(401).send('Invalid credentials');
@@ -31,6 +33,7 @@ export class AuthController {
   }
 
   @Post('refresh')
+  @ApiOperation({ summary: 'Refresh access token' })
   async refresh(@Req() req: Request, @Res() res: Response) {
     const { cookies } = req as Request & { cookies?: Record<string, string> };
     const token = cookies?.refresh;
@@ -45,6 +48,7 @@ export class AuthController {
   }
 
   @Post('logout')
+  @ApiOperation({ summary: 'User logout' })
   async logout(@Req() req: Request, @Res() res: Response) {
     const { cookies } = req as Request & { cookies?: Record<string, string> };
     const token = cookies?.refresh;

--- a/server/src/auth/dto/login.dto.ts
+++ b/server/src/auth/dto/login.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class LoginDto {
+  @ApiProperty({ example: 'alice@example.com' })
+  email!: string;
+
+  @ApiProperty({ example: 'pass1234' })
+  password!: string;
+}

--- a/server/src/calendars/calendar.controller.ts
+++ b/server/src/calendars/calendar.controller.ts
@@ -1,6 +1,22 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, Query } from '@nestjs/common';
-import { ApiBody, ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
-import { Calendar } from './calendar.interface';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { CreateCalendarDto } from './dto/create-calendar.dto';
+import { UpdateCalendarDto } from './dto/update-calendar.dto';
 import { CalendarService } from './calendar.service';
 
 @ApiTags('calendars')
@@ -10,21 +26,8 @@ export class CalendarController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new calendar' })
-  @ApiBody({
-    description: 'Calendar data',
-    examples: {
-      default: {
-        summary: 'Example calendar',
-        value: {
-          userId: 'user123',
-          name: 'Work',
-          color: '#FF0000',
-          description: 'Work related events',
-        },
-      },
-    },
-  })
-  create(@Body() calendar: Omit<Calendar, 'id'>) {
+  @ApiBody({ type: CreateCalendarDto })
+  create(@Body() calendar: CreateCalendarDto) {
     return this.calendarService.create(calendar);
   }
 
@@ -50,8 +53,8 @@ export class CalendarController {
   @Put(':id')
   @ApiOperation({ summary: 'Update a calendar by id' })
   @ApiParam({ name: 'id', description: 'ID of the calendar', example: '1' })
-  @ApiBody({ description: 'Fields to update', examples: { rename: { summary: 'Rename', value: { name: 'Personal' } } } })
-  update(@Param('id') id: string, @Body() update: Partial<Calendar>) {
+  @ApiBody({ type: UpdateCalendarDto })
+  update(@Param('id') id: string, @Body() update: UpdateCalendarDto) {
     return this.calendarService.update(id, update);
   }
 

--- a/server/src/calendars/dto/create-calendar.dto.ts
+++ b/server/src/calendars/dto/create-calendar.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateCalendarDto {
+  @ApiProperty({ example: 'user123' })
+  userId!: string;
+
+  @ApiProperty({ example: 'Work' })
+  name!: string;
+
+  @ApiPropertyOptional({ example: '#FF0000' })
+  color?: string;
+
+  @ApiPropertyOptional({ example: 'Work related events' })
+  description?: string;
+}

--- a/server/src/calendars/dto/update-calendar.dto.ts
+++ b/server/src/calendars/dto/update-calendar.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCalendarDto } from './create-calendar.dto';
+
+export class UpdateCalendarDto extends PartialType(CreateCalendarDto) {}

--- a/server/src/schedules/dto/create-schedule.dto.ts
+++ b/server/src/schedules/dto/create-schedule.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateScheduleDto {
+  @ApiProperty({ example: 'user123' })
+  userId!: string;
+
+  @ApiProperty({ example: 'calendar123' })
+  calendarId!: string;
+
+  @ApiProperty({ example: 'Team meeting' })
+  title!: string;
+
+  @ApiProperty({ example: '20231001090000', description: 'YYYYMMDDHHmmss' })
+  startDateTime!: string;
+
+  @ApiProperty({ example: '20231001100000', description: 'YYYYMMDDHHmmss' })
+  endDateTime!: string;
+
+  @ApiPropertyOptional()
+  allDay?: boolean;
+
+  @ApiPropertyOptional({ example: 'Seoul HQ' })
+  location?: string;
+
+  @ApiPropertyOptional({ description: 'Alarm object' })
+  alarm?: any;
+
+  @ApiPropertyOptional({ example: '#FF5733' })
+  color?: string;
+
+  @ApiPropertyOptional()
+  isRepeat?: boolean;
+
+  @ApiPropertyOptional({ example: 'repeat123' })
+  repeatId?: string;
+
+  @ApiPropertyOptional({ type: [Object] })
+  participants?: any[];
+
+  @ApiPropertyOptional({ example: 'Monthly planning meeting' })
+  description?: string;
+}

--- a/server/src/schedules/dto/update-schedule.dto.ts
+++ b/server/src/schedules/dto/update-schedule.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateScheduleDto } from './create-schedule.dto';
+
+export class UpdateScheduleDto extends PartialType(CreateScheduleDto) {}

--- a/server/src/schedules/schedule.controller.ts
+++ b/server/src/schedules/schedule.controller.ts
@@ -15,7 +15,8 @@ import {
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
-import { Schedule } from './schedule.interface';
+import { CreateScheduleDto } from './dto/create-schedule.dto';
+import { UpdateScheduleDto } from './dto/update-schedule.dto';
 import { ScheduleService } from './schedule.service';
 
 @ApiTags('schedules')
@@ -25,34 +26,15 @@ export class ScheduleController {
 
   @Post()
   @ApiOperation({ summary: 'Create a new schedule' })
-  @ApiBody({
-    description: 'Details of the schedule to create',
-    examples: {
-      default: {
-        summary: 'Example schedule',
-        value: {
-          userId: 'user123',
-          calendarId: 'calendar123',
-          title: 'Team meeting',
-          startDateTime: '20231001090000', // YYYYMMDDHHmmss
-          endDateTime: '20231001100000', // YYYYMMDDHHmmss
-          location: 'Seoul HQ',
-          alarm: {}, // Example alarm object
-          color: '#FF5733', // Example hex color code
-          isRepeat: false,
-          repeatId: null, // No repeat rule
-          participants: ['alice@example.com', 'bob@example.com'],
-          description: 'Monthly planning meeting',
-        },
-      },
-    },
-  })
-  create(@Body() schedule: Omit<Schedule, 'id'>) {
+  @ApiBody({ type: CreateScheduleDto })
+  create(@Body() schedule: CreateScheduleDto) {
     return this.scheduleService.create(schedule);
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all schedules (optionally by userId and calendarId)' })
+  @ApiOperation({
+    summary: 'Get all schedules (optionally by userId and calendarId)',
+  })
   @ApiQuery({
     name: 'userId',
     required: false,
@@ -65,7 +47,10 @@ export class ScheduleController {
     description: 'Filter schedules for the given calendar ID',
     example: 'calendar123',
   })
-  findAll(@Query('userId') userId?: string, @Query('calendarId') calendarId?: string) {
+  findAll(
+    @Query('userId') userId?: string,
+    @Query('calendarId') calendarId?: string,
+  ) {
     return this.scheduleService.findAll(userId, calendarId);
   }
 
@@ -87,16 +72,8 @@ export class ScheduleController {
     description: 'ID of the schedule to update',
     example: 'a1b2c3',
   })
-  @ApiBody({
-    description: 'Partial schedule fields to update',
-    examples: {
-      updateTitle: {
-        summary: 'Update the title and time',
-        value: { title: 'Updated meeting', startTime: '10:00' },
-      },
-    },
-  })
-  update(@Param('id') id: string, @Body() update: Partial<Schedule>) {
+  @ApiBody({ type: UpdateScheduleDto })
+  update(@Param('id') id: string, @Body() update: UpdateScheduleDto) {
     return this.scheduleService.update(id, update);
   }
 

--- a/server/src/users/dto/create-user.dto.ts
+++ b/server/src/users/dto/create-user.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateUserDto {
+  @ApiProperty({ example: 'Alice' })
+  name!: string;
+
+  @ApiProperty({ example: 'alice@example.com' })
+  email!: string;
+
+  @ApiProperty({ example: 'pass1234' })
+  password!: string;
+}

--- a/server/src/users/dto/reset-password.dto.ts
+++ b/server/src/users/dto/reset-password.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResetPasswordDto {
+  @ApiProperty({ example: 'alice@example.com' })
+  email!: string;
+
+  @ApiProperty({ example: 'newpass' })
+  password!: string;
+}

--- a/server/src/users/dto/update-user.dto.ts
+++ b/server/src/users/dto/update-user.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateUserDto } from './create-user.dto';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {}

--- a/server/src/users/user.controller.ts
+++ b/server/src/users/user.controller.ts
@@ -8,7 +8,9 @@ import {
   Put,
 } from '@nestjs/common';
 import { ApiBody, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
-import { User } from './user.interface';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
 import { UserService } from './user.service';
 
 @ApiTags('users')
@@ -18,20 +20,8 @@ export class UserController {
 
   @Post('register')
   @ApiOperation({ summary: 'Create a new user (with default calendar)' })
-  @ApiBody({
-    description: 'User data',
-    examples: {
-      default: {
-        summary: 'Example user',
-        value: {
-          name: 'Alice',
-          email: 'alice@example.com',
-          password: 'pass1234',
-        },
-      },
-    },
-  })
-  register(@Body() user: Omit<User, 'id'>) {
+  @ApiBody({ type: CreateUserDto })
+  register(@Body() user: CreateUserDto) {
     return this.userService.create(user);
   }
 
@@ -51,22 +41,15 @@ export class UserController {
   @Put(':id')
   @ApiOperation({ summary: 'Update a user by id' })
   @ApiParam({ name: 'id', description: 'ID of the user', example: '1' })
-  @ApiBody({
-    description: 'Fields to update',
-    examples: { rename: { summary: 'Rename', value: { name: 'Bob' } } },
-  })
-  update(@Param('id') id: string, @Body() update: Partial<User>) {
+  @ApiBody({ type: UpdateUserDto })
+  update(@Param('id') id: string, @Body() update: UpdateUserDto) {
     return this.userService.update(id, update);
   }
 
   @Post('reset-password')
   @ApiOperation({ summary: 'Reset password by email' })
-  @ApiBody({
-    schema: {
-      example: { email: 'alice@example.com', password: 'newpass' },
-    },
-  })
-  async resetPassword(@Body() body: { email: string; password: string }) {
+  @ApiBody({ type: ResetPasswordDto })
+  async resetPassword(@Body() body: ResetPasswordDto) {
     const user = await this.userService.findByEmail(body.email);
     if (!user) return undefined;
     return this.userService.update(user.id, { password: body.password });

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -73,4 +73,3 @@ export function log(title: string, message: string) {
   const { className, funcName } = getCallerInfo();
   logger.info(message, { className, funcName, title });
 }
-


### PR DESCRIPTION
## Summary
- add DTO classes for Swagger schema generation
- update controllers to use the new DTOs
- document auth endpoints

## Testing
- `npm test`
- `npx eslint "src/**/*.ts"`


------
https://chatgpt.com/codex/tasks/task_e_6875ceab9b98832a81fb4e5e6b0e4297